### PR TITLE
Check kernel version and add DWARF config option

### DIFF
--- a/easylkb.py
+++ b/easylkb.py
@@ -153,6 +153,12 @@ class Kbuilder:
         KConfigFile = open(self.KConfig, "r")
         ConfigFile = open(f"{self.KPath}.config", "a+") # This is the config file to write
         ConfigFile.write(KConfigFile.read())
+        
+        #Check if version is 5.12 or greater and if so add generic DWARF option (fixes issue #4)
+        if float(self.KVersion) >= 5.12:
+            dwarf_config = "CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y"
+            ConfigFile.write(dwarf_config)
+
         ConfigFile.close()
         KConfigFile.close()
 


### PR DESCRIPTION
This fixes the issue with debugging kernel images that was outline in issue #4.  I've tested this on kernel versions 6.5, 6.6, and 6.7

This config option is only available on kernel versions starting from 5.12 according to: https://cateee.net/lkddb/web-lkddb/DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT.html