### PR TITLE
Check kernel version and add DWARF config option if kernel version is 5.12 or later

### DIFF
--- a/easylkb.py
+++ b/easylkb.py
@@ -153,6 +153,12 @@ class Kbuilder:
         KConfigFile = open(self.KConfig, "r")
         ConfigFile = open(f"{self.KPath}.config", "a+") # This is the config file to write
         ConfigFile.write(KConfigFile.read())
+        
+        #Check if version is 5.12 or greater and if so add generic DWARF option (fixes issue #4)
+        if float(self.KVersion) >= 5.12:
+            dwarf_config = "CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y"
+            ConfigFile.write(dwarf_config)
+
         ConfigFile.close()
         KConfigFile.close()
 

--- a/easylkb.py
+++ b/easylkb.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from packaging.version import Version
+
 import argparse
 import subprocess
 import re
@@ -155,7 +157,8 @@ class Kbuilder:
         ConfigFile.write(KConfigFile.read())
         
         #Check if version is 5.12 or greater and if so add generic DWARF option (fixes issue #4)
-        if float(self.KVersion) >= 5.12:
+        if Version(self.KVersion) >=Version("5.12"):
+            self.logb("log", f"Appending DWARF debug option to {self.KPath}.config")
             dwarf_config = "CONFIG_DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT=y"
             ConfigFile.write(dwarf_config)
 


### PR DESCRIPTION
This fixes the issue with debugging kernel images that was outline in issue https://github.com/deepseagirl/easylkb/issues/4. I've tested this on kernel versions 6.5, 6.6, and 6.7

This config option is only available on kernel versions starting from 5.12 according to: https://cateee.net/lkddb/web-lkddb/DEBUG_INFO_DWARF_TOOLCHAIN_DEFAULT.html